### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "moment": "^2.22.2",
     "mongoose": "^5.3.7",
     "morgan": "~1.9.0",
-    "npm": "^6.7.0",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "popper.js": "^1.14.4",


### PR DESCRIPTION

Hello rerwinx!

It seems like you have npm as one of your (dev-) dependency in ContosoAir.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
